### PR TITLE
 preg_position gives random results if invalid group is given 

### DIFF
--- a/lib_mysqludf_preg_position.c
+++ b/lib_mysqludf_preg_position.c
@@ -246,7 +246,7 @@ longlong preg_position( UDF_INIT *initid, UDF_ARGS *args, char *is_null,
             groupnum = pregGetGroupNum( re , args , 2 ) ;
 
         // If groupnum found, get the offset
-        if( groupnum >= 0 && groupnum < oveccount )
+        if( groupnum >= 0 && groupnum < (oveccount/3) )
         {
             // ovec is in pairs of starting and ending offsets.  (ie. 
             // ovec[0] is start of whole match, ovec[1] is end of whole 


### PR DESCRIPTION
If you were to do something like:

```
SELECT preg_position( '/(o)/', 'The quick brown fox.', 2, 1 );
```

it would give you a random value instead of NULL.

The code for it shows that it sets it's count to be 3*n+1 (for n groups) in preg.c in pregCreateOffsetsVector() :

```
152 
153     ++oveccount ;    // for 0
154     oveccount *= 3 ; // 2 for offset info , 1 for pcre internals
155     ovec  = malloc( sizeof( int ) * oveccount ) ;
156     if( !ovec )
```

and this is used in preg_position() :
