### PR TITLE
Couple small Readme.md fixes and MacOSx MAMP Install Tip

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -23,6 +23,13 @@ Example  (on macosx with fink)
 
 Please use:  ./configure --help to see the other options
 
+Example  (on macosx with MAMP)
+------------------------------
+Follow the example at the link below to compile Mysql and place the lib files in the correct folders
+http://addto.it/Patching-MAMP-2.0.5-to-work-with-Sphinx-2.02
+
+Then configure lib_mysqludf_preg with 
+./configure --with-mysql=/Applications/MAMP/Library/bin/mysql_config
 
 == Compile == 
 Type make

--- a/README.md
+++ b/README.md
@@ -38,13 +38,17 @@ version of lib_mysqludf_preg.
 
 Some examples:
 -------------
-- SELECT PREG_CAPTURE( '/(new)\\s+([a-zA-Z]*)(.*)/i' , description, 2  ) FROM state WHERE description LIKE 'new%' ;
+- SELECT captured, description FROM
+    (SELECT PREG_CAPTURE( '/(new)\\\\s+([a-zA-Z]*)(.*)/i' , description, 2  ) as captured FROM state WHERE description LIKE 'new%') as t1
+  WHERE captured IS NOT NULL;
 
-- SELECT PREG_POSITION( '/(new)\\s+([a-zA-Z]*)(.*)/i' , description, 2  ) FROM state WHERE description LIKE 'new%' ;
+- SELECT position, description FROM
+    (SELECT PREG_POSITION( '/(new)\\\\s+([a-zA-Z]*)(.*)/i' , description, 2  ) as position FROM state WHERE description LIKE 'new%') as t1
+  WHERE position IS NOT NULL;
 
 - SELECT * from products WHERE PREG_RLIKE( '/hemp/i' , products.title )
 
-- SELECT PREG_REPLACE( '/fox/i' , 'dog' , 'The brown fox' ) 
+- SELECT CONVERT( PREG_REPLACE( '/fox/i' , 'dog' , 'The brown fox' ) USING UTF8) as replaced;
 
 Please see test/lib_udfmysql_preg.test and test/lib_udfmysql_preg.result for 
 more examples.


### PR DESCRIPTION
queries needed double \ to escape. The error may have been due to
markdown's escaping \\ into \.
also added NOT NULL condition to reduce possible confusion that may
cause users to think there is an error in the library.
without CONVERT, PREG_REPLACE returns a binary result, Mysql Workbench
displays as if the results are empty, which is highly confusing.
